### PR TITLE
Handle case where animate callbacks are null.

### DIFF
--- a/ember-animate.js
+++ b/ember-animate.js
@@ -130,11 +130,13 @@
 
 			Ember.run.once(Ember.View, 'notifyMutationListeners');
 
-			for (i = 0; i < view._animateOutCallbacks.length; i ++) {
-				run(view._animateOutCallbacks[i]);
-			}
+			if (view._animateOutCallbacks != null) {
+				for (i = 0; i < view._animateOutCallbacks.length; i ++) {
+					run(view._animateOutCallbacks[i]);
+				}
 
-			view._animateOutCallbacks = null;
+				view._animateOutCallbacks = null;
+			}
 		};
 
 		if (view.$el) {


### PR DESCRIPTION
This usually caused an error "Uncaught TypeError: Cannot read property 'length' of null" on line 133 when removing a view.
