### PR TITLE
Fix bug where elements weren't actually getting destroyed.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-animate",
   "main": "ember-animate.js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/gigafied/ember-animate",
   "authors": [
     "Taka Kojima <taka@gigafied.com>"

--- a/ember-animate.js
+++ b/ember-animate.js
@@ -133,20 +133,13 @@
 					}
 				}
 
-				this.isDestroying = this.hasAnimatedOut;
+				this.isDestroying = false;
 
 				_super.call(this);
-
-				// destroy the element -- this will avoid each child view destroying
-				// the element over and over again...
-				if (!this.removedFromDOM) {
-					this.destroyElement();
-				}
 
 				// remove from parent if found. Don't call removeFromParent,
 				// as removeFromParent will try to remove the element from
 				// the DOM again.
-
 				if (this._parentView) {
 					this._parentView.removeChild(this);
 				}


### PR DESCRIPTION
This was causing chainNodes to not get cleaned up and therefore a memory leak. Also bump version.

Described in detail in [this bug](https://github.com/gigafied/ember-animate/issues/20).

You can see a working version [here](http://jsfiddle.net/L7zBb/4/).
