### PR TITLE
remove transitionTo line

### DIFF
--- a/ember-animate.js
+++ b/ember-animate.js
@@ -146,8 +146,6 @@
 
 				this.isDestroying = true;
 
-				this.transitionTo('destroying', false);
-
 				delete this.$;
 				delete this.$el;
 


### PR DESCRIPTION
This line causes a deprecation warning in Ember 1.7 beta.

Calling _super should call _transitionTo('destroying') anyway.
