### PR TITLE
Simple Ember CLI Support

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "analytics": false
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = space
+indent_size = 2
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/.ember-cli
+++ b/.ember-cli
@@ -1,0 +1,9 @@
+{
+  /**
+    Ember CLI sends analytics information by default. The data is completely
+    anonymous, but there are times when you might want to disable this behavior.
+
+    Setting `disableAnalytics` to true will prevent any data from being sent.
+  */
+  "disableAnalytics": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+
+# dependencies
+/node_modules
+/bower_components
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage/*
+/libpeerconnection.log
+npm-debug.log
+testem.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,32 @@
+{
+  "predef": [
+    "document",
+    "window",
+    "-Promise"
+  ],
+  "browser": true,
+  "boss": true,
+  "curly": true,
+  "debug": false,
+  "devel": true,
+  "eqeqeq": true,
+  "evil": true,
+  "forin": false,
+  "immed": false,
+  "laxbreak": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": false,
+  "nonew": false,
+  "nomen": false,
+  "onevar": false,
+  "plusplus": false,
+  "regexp": false,
+  "undef": true,
+  "sub": true,
+  "strict": false,
+  "white": false,
+  "eqnull": true,
+  "esnext": true,
+  "unused": true
+}

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,0 +1,21 @@
+/* jshint node: true */
+/* global require, module */
+
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+
+var app = new EmberAddon();
+
+// Use `app.import` to add additional libraries to the generated
+// output files.
+//
+// If you need to use different assets in different
+// environments, specify an object as the first parameter. That
+// object's keys should be the environment name and the values
+// should be the asset to use in that environment.
+//
+// If the library that you are including contains AMD or ES6
+// modules that you would like to import into your application
+// please specify an object with the list of modules as keys
+// along with the exports of each module as its value.
+
+module.exports = app.toTree();

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,38 @@
+This software is released under the terms of the MIT License.
+
+(c) 2014 Taka Kojima (the "Author").
+All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+Distributions of all or part of the Software intended to be used
+by the recipients as they would use the unmodified Software,
+containing modifications that substantially alter, remove, or
+disable functionality of the Software, outside of the documented
+configuration mechanisms provided by the Software, shall be
+modified such that the Author's bug reporting email addresses and
+urls are either replaced with the contact information of the
+parties responsible for the changes, or removed entirely.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+Except where noted, this license applies to any and all software
+programs and associated documentation files created by the
+Author, when distributed with the Software.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ App.ExampleView = Ember.View.extend({
 });
 ````
 
+If you're using Ember-CLI, you can install this library as an Addon, like so:
+
+```js
+ember install:addon ember-animate
+```
+
 That's it! Super easy!
 
 ####Ember Animate exposes 6 different methods for you:

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "predef": [
+    "console"
+  ]
+}

--- a/blueprints/ember-animate/index.js
+++ b/blueprints/ember-animate/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  description: 'Adds the ember-animate bower package to your Ember-CLI project.',
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject('ember-animate', '0.3.6');
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = {
+  name: 'ember-animate',
+
+  included: function(app) {
+    this._super.included(app);
+    this.app.import(app.bowerDirectory + '/ember-animate/ember-animate.js');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "ember-animate",
+  "version": "0.3.6",
+  "description": "Animations for Ember.js",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "start": "ember server",
+    "build": "ember build",
+    "test": "ember test"
+  },
+  "repository": "https://github.com/gigafied/ember-animate",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "Taka Kojima <taka@gigafied.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.0.0",
+    "broccoli-ember-hbs-template-compiler": "^1.6.1",
+    "ember-cli": "0.1.7",
+    "ember-cli-content-security-policy": "0.3.0",
+    "ember-cli-dependency-checker": "0.0.7",
+    "ember-cli-6to5": "0.2.1",
+    "ember-cli-ic-ajax": "0.1.1",
+    "ember-cli-inject-live-reload": "^1.3.0",
+    "ember-cli-qunit": "0.1.2",
+    "ember-data": "1.0.0-beta.12",
+    "ember-export-application-global": "^1.0.0",
+    "express": "^4.8.5",
+    "glob": "^4.0.5"
+  },
+  "keywords": [
+    "ember-addon"
+  ],
+  "ember-addon": {
+    "configPath": "tests/dummy/config"
+  }
+}


### PR DESCRIPTION
This PR provides simple Ember-CLI support via 

```js
ember install:addon ember-animate
```

There's no testing yet - but if you'd like I'd be happy to write a couple simple tests - and include a ```.travis``` file?