### PR TITLE
Extend `Ember.View`

### DIFF
--- a/ember-animate.js
+++ b/ember-animate.js
@@ -1,15 +1,28 @@
 (function () {
 
     var run,
-        destroying$;
+        destroying$,
+        EmberAnimateView,
+        EmberAnimateContainerView,
+        root,
+        objectTypes;
 
-    var run = function (fn) {
+    objectTypes = {
+        'function': true,
+        'object': true
+    };
+
+    root = (objectTypes[typeof window] && window !== (this && this.window)) ? window : this;
+
+    run = function (fn) {
         if (fn && typeof fn === 'function') {
             return fn();
         }
     };
 
-    Ember.View.reopen({
+    EmberAnimateView = Ember.View.extend();
+
+    EmberAnimateView.reopen({
 
         isAnimatingIn : false,
         isAnimatingOut : false,
@@ -161,7 +174,9 @@
         }
     });
 
-    Ember.ContainerView.reopen({
+    EmberAnimateContainerView = Ember.ContainerView.extend();
+
+    EmberAnimateContainerView.reopen({
 
         currentView : null,
         activeView : null,
@@ -257,5 +272,8 @@
         })
 
     });
+
+    root.EmberAnimateView = EmberAnimateView;
+    root.EmberAnimateContainerView = EmberAnimateContainerView;
 
 })();

--- a/ember-animate.js
+++ b/ember-animate.js
@@ -2,17 +2,8 @@
 
     var run,
         destroying$,
-        EmberAnimateView,
-        EmberAnimateContainerView,
         root,
         objectTypes;
-
-    objectTypes = {
-        'function': true,
-        'object': true
-    };
-
-    root = (objectTypes[typeof window] && window !== (this && this.window)) ? window : this;
 
     run = function (fn) {
         if (fn && typeof fn === 'function') {
@@ -20,9 +11,9 @@
         }
     };
 
-    EmberAnimateView = Ember.View.extend();
+    Ember.AnimateView = Ember.View.extend();
 
-    EmberAnimateView.reopen({
+    Ember.AnimateView.reopen({
 
         isAnimatingIn : false,
         isAnimatingOut : false,
@@ -174,9 +165,9 @@
         }
     });
 
-    EmberAnimateContainerView = Ember.ContainerView.extend();
+    Ember.AnimateContainerView = Ember.ContainerView.extend();
 
-    EmberAnimateContainerView.reopen({
+    Ember.AnimateContainerView.reopen({
 
         currentView : null,
         activeView : null,
@@ -272,8 +263,5 @@
         })
 
     });
-
-    root.EmberAnimateView = EmberAnimateView;
-    root.EmberAnimateContainerView = EmberAnimateContainerView;
 
 })();


### PR DESCRIPTION
Rather than reopening `Ember.View`, extend so that it can be used however someone may want to use it rather than universal by default. 

Initial reason for change was because this code broke on HTMLBars. Each helper runs through `afterRender` and is not able to use `this.$()` without a `tagName`. This shouldn't be a requirement, therefore extending is the best solution then it can be used where ever.
