### PR TITLE
Fix blueprint for ember-cli

### DIFF
--- a/blueprints/ember-animate/index.js
+++ b/blueprints/ember-animate/index.js
@@ -1,6 +1,11 @@
 module.exports = {
   description: 'Adds the ember-animate bower package to your Ember-CLI project.',
-
+  
+  normalizeEntityName: function() {
+    // allows us to run ember -g ember-animate and not blow up
+    // because ember cli normally expects the format
+    // ember generate <entitiyName> <blueprint>
+  },
   afterInstall: function() {
     return this.addBowerPackageToProject('ember-animate', '0.3.7');
   }


### PR DESCRIPTION
allows us to run ember -g ember-animate and not blow up because ember cli normally expects the ember generate <entitiyName> <blueprint>
